### PR TITLE
Fixed an issue which occurs if the page is scrolled down a bit:

### DIFF
--- a/jquery-menu-editor.js
+++ b/jquery-menu-editor.js
@@ -204,8 +204,8 @@
             el.css({
                 'width': el.width(),
                 'position': 'absolute',
-                'top': elXY.top - elMT,
-                'left': elXY.left - elML
+                'top': elXY.top - $(window).scrollTop() - elMT,
+                'left': elXY.left - $(window).scrollLeft() - elML
             }).prependTo(base);
 
             placeholderNode.css({
@@ -292,7 +292,7 @@
                 isHintTarget = false;
             }
             offset = targetEl.offset();
-            cEl.el.animate({left: offset.left - state.cEl.mL, top: offset.top - state.cEl.mT}, 250,
+            cEl.el.animate({left: offset.left - $(window).scrollLeft() - state.cEl.mL, top: offset.top - $(window).scrollTop() - state.cEl.mT}, 250,
                     function ()  // complete callback
                     {
                         tidyCurrEl(cEl);
@@ -408,8 +408,9 @@
         function setCElPos(e, state){
             var cEl = state.cEl;
             cEl.el.css({
-                'top': e.pageY - cEl.xyOffsetDiff.Y - cEl.mT,
-                'left': e.pageX - cEl.xyOffsetDiff.X - cEl.mL
+                           'position': 'fixed',
+                           'top': e.clientY - cEl.xyOffsetDiff.Y - cEl.mT,
+                           'left': e.clientX - cEl.xyOffsetDiff.X - cEl.mL
             }); //Fix david (;)
 
         }


### PR DESCRIPTION
* The dragged element is shown way below the mouse cursor.

Fixed an issue with inconsistent positioning of the dragged element in several website layouts:
* The dragged element was shown in different positions depending on any position-rules of any parent dom-elements

* startDrag(), endDrag(), setCElPos()
** css-rules for 'top' and 'left' are calculated with the scroll position of the page in mind
** css-rule for 'position' is 'fixed', which causes 'top' and 'left' being relative to the page not a parent with a position-rule